### PR TITLE
Use format instead for number-to-string for Actual column in developer summary.

### DIFF
--- a/scrum.el
+++ b/scrum.el
@@ -227,7 +227,7 @@
 
       (insert "\n| " (car developer)
               " | " (number-to-string est)
-              " | " (number-to-string act)
+              " | " (format "%.2f" act)
               " | " (number-to-string done)
               " | " (number-to-string rem)
               " | " (format-time-string "%Y-%m-%d" (scrum-get-finish-date rem (cdr developer)))


### PR DESCRIPTION
Same should be done on the TASKS LIST but since that's filled with
org-ctrl-c-ctrl-c then the rounding isn't easily hackable.
